### PR TITLE
Responsiveness and other ux improvements

### DIFF
--- a/src/app/[username]/page.tsx
+++ b/src/app/[username]/page.tsx
@@ -70,8 +70,6 @@ export default async function Page({
 
         {auth?.user.id === user.id && <DumpForm />}
 
-
-
         <ul className="gap-4">
           {dumps.map((dump) => (
             <li className="w-full" key={dump.id}>

--- a/src/app/[username]/userdump.tsx
+++ b/src/app/[username]/userdump.tsx
@@ -57,7 +57,7 @@ const UserDump = ({ dump, auth, user }: { dump: Dumps, auth: Session | null, use
         const dmp = _dump.current.getBoundingClientRect();
 
         const x = dmp.left + dmp.width/2 - bin.left - bin.width/2;
-        const y = dmp.top + dmp.height*3/4 - bin.top - bin.height/2;
+        const y = dmp.top + 100*3/4 - bin.top - bin.height/2;
 
         lid.current.parentElement!.style.setProperty("--x", `${x}px`);
         lid.current.parentElement!.style.setProperty("--y", `${y}px`);

--- a/src/app/[username]/userdump.tsx
+++ b/src/app/[username]/userdump.tsx
@@ -50,7 +50,7 @@ const UserDump = ({ dump, auth, user }: { dump: Dumps, auth: Session | null, use
 
     }
 
-    useEffect(() => {
+    function dumpPosition() {
         if (!_dump.current || !lid.current) return;
         
         const bin = lid.current.parentElement!.getBoundingClientRect();
@@ -61,6 +61,17 @@ const UserDump = ({ dump, auth, user }: { dump: Dumps, auth: Session | null, use
 
         lid.current.parentElement!.style.setProperty("--x", `${x}px`);
         lid.current.parentElement!.style.setProperty("--y", `${y}px`);
+    }
+
+    useEffect(() => {
+
+        dumpPosition();
+
+        window.addEventListener("resize", dumpPosition);
+
+        return () => {
+            window.removeEventListener("resize", dumpPosition);
+        }
 
     }, [])
 
@@ -112,8 +123,8 @@ const UserDump = ({ dump, auth, user }: { dump: Dumps, auth: Session | null, use
                         {dump.content}
                     </Markdown>
                 </div>
-                <button onClick={yesDeleteIt} onMouseEnter={() => lid.current?.classList.add("open")} onMouseLeave={() => lid.current?.classList.remove('open')} className={`${deleteConfirmation && "on"} confirm-btn-y absolute top-[75%] -translate-y-1/2 left-[30%]`}>yes</button>
-                <button onClick={() => ( setDeleteConfirmation(false) )} className={`${deleteConfirmation && "on"} confirm-btn-n absolute top-[75%] -translate-y-1/2 right-[30%]`}>no</button>
+                <button onClick={yesDeleteIt} onMouseEnter={() => lid.current?.classList.add("open")} onMouseLeave={() => lid.current?.classList.remove('open')} className={`${deleteConfirmation && "on"} confirm-btn-y absolute top-[75%] -translate-y-1/2 left-[25%] md:left-[30%]`}>yes</button>
+                <button onClick={() => ( setDeleteConfirmation(false) )} className={`${deleteConfirmation && "on"} confirm-btn-n absolute top-[75%] -translate-y-1/2 right-[25%] md:right-[30%]`}>no</button>
                 <div ref={ball} className="psuedo-dump" />
             </div>
             {

--- a/src/app/dumpGallery.tsx
+++ b/src/app/dumpGallery.tsx
@@ -10,7 +10,7 @@ function DumpGallery({ top100PublicDumps }: { top100PublicDumps: Dumps[] }) {
     <ResponsiveMasonry columnsCountBreakPoints={{ 350: 1, 750: 2}}>
       <Masonry gutter="16px">
         {top100PublicDumps.map((dump) => (
-          <Dump dump={dump} />
+          <Dump key={dump.id} dump={dump} />
         ))}
       </Masonry>
     </ResponsiveMasonry>

--- a/src/app/dumpform.tsx
+++ b/src/app/dumpform.tsx
@@ -44,12 +44,12 @@ function DumpForm({ className }: { className?: string }) {
       className={`mt-4 w-full ${className}`}
     >
       <Textarea required id="dumpcontent" placeholder="What's on your mind?" disabled={isDumping} />
-      <div className="mt-4 flex justify-between">
+      <div className="mt-4 flex justify-between flex-row-reverse">
+        <Button type="submit" disabled={isDumping}>Dump</Button>
         <div className="flex items-center gap-2">
           <Switch defaultChecked={true} id="isPrivate" disabled={isDumping} />
           <Label htmlFor="isPrivate">Public</Label>
         </div>
-        <Button type="submit" disabled={isDumping}>Dump</Button>
       </div>
     </form>
   );

--- a/src/app/dumpform.tsx
+++ b/src/app/dumpform.tsx
@@ -10,7 +10,7 @@ import { Label } from "@/components/ui/label";
 function DumpForm({ className }: { className?: string }) {
 
   const [isDumping, setIsDumping] = useState(false);
-  const inputRef = useRef<HTMLFormElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
 
   const submitDump = async (e: FormEvent) => {
     e.preventDefault();

--- a/src/components/dump.tsx
+++ b/src/components/dump.tsx
@@ -7,17 +7,17 @@ import Link from "next/link";
 
 export function Dump({ dump }: { dump: Dumps }) {
   return (
-    <div className="rounded-xl border p-4 dark:border-gray-500">
+    <div className="rounded-2xl border p-4 dark:border-white/20 transition-[border-color] dark:hover:border-white/50">
       <div className="flex items-center justify-between gap-2">
         <div className="flex flex-col">
           <Link href={`/@${dump.createdByName}`} className="flex items-center gap-2">
-            <Avatar className="h-6 w-6">
+            <Avatar className="h-7 w-7">
               <AvatarImage src={`/@${dump.createdByName}/pfp`} />
               <AvatarFallback>{dump.createdByName.slice(0, 2)}</AvatarFallback>
             </Avatar>
             <div>
-              <span>{dump.createdByName}</span>
-              <div className="flex text-sm text-gray-500 dark:text-gray-400">
+              <span className="text-sm">{dump.createdByName}</span>
+              <div className="flex text-xs text-gray-500 dark:text-gray-400">
                 {new Date(dump.createdAt).toLocaleString("en-US", {
                   day: "numeric",
                   month: "long",

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -111,10 +111,12 @@
 
 .dump {
   position: relative;
+
+  transition: height 0.3s ease;
 }
 
 .dump.confirm-delete {
-  @apply border-none;
+  @apply border-none h-[100px];
 }
 
 .psuedo-dump {
@@ -124,7 +126,7 @@
 }
 
 .dump.confirm-delete .psuedo-dump {
-  @apply top-[15%] left-[50%] w-[15px] h-[15px] bg-border rounded-full;
+  @apply top-[15%] left-[50%] w-[15px] h-[15px] bg-white/30 rounded-full;
 
   animation: ball 0.5s ease-in-out forwards;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -171,10 +171,10 @@
   @apply scale-100;
 }
 
-.confirm-btn-y:hover {
-  @apply bg-destructive/20 text-destructive;
+.confirm-btn-y {
+  @apply bg-destructive/20 text-destructive md:bg-transparent md:text-inherit md:hover:bg-destructive/20 md:hover:text-destructive;
 }
 
-.confirm-btn-n:hover {
-  @apply bg-primary/20 text-primary;
+.confirm-btn-n {
+  @apply bg-primary/20 text-primary md:text-inherit md:bg-transparent md:hover:bg-primary/20 md:hover:text-primary;
 }


### PR DESCRIPTION
- fix delete confirmation of long dumps
- improve responsiveness
- update dump card (changed border)
- rearrange the DOM elements in `<DumpForm>`, so that `TAB` from `<textarea>` would focus on submit button
- type any letter of the alphabet and it will auto focus on dumpform (except if u are holding ctrl, shift, cmd, alt etc)
- `Shift`+`Enter` when `<DumpForm>` is focused submits the dump